### PR TITLE
fix: use stable.<pkg> to access stable pkgs

### DIFF
--- a/home_manager/users/lucas/home.nix
+++ b/home_manager/users/lucas/home.nix
@@ -22,7 +22,7 @@
       # Add overlays your own flake exports (from overlays and pkgs dir):
       outputs.overlays.additions
       outputs.overlays.modifications
-      outputs.overlays.unstable-packages
+      outputs.overlays.stable-packages
 
       # You can also add overlays exported from other flakes:
       # neovim-nightly-overlay.overlays.default

--- a/nixos/configuration.nix
+++ b/nixos/configuration.nix
@@ -37,7 +37,7 @@
       # Add overlays your own flake exports (from overlays and pkgs dir):
       outputs.overlays.additions
       outputs.overlays.modifications
-      outputs.overlays.unstable-packages
+      outputs.overlays.stable-packages
 
       # You can also add overlays exported from other flakes:
       # neovim-nightly-overlay.overlays.default

--- a/overlays/default.nix
+++ b/overlays/default.nix
@@ -23,8 +23,8 @@
 
   # When applied, the unstable nixpkgs set (declared in the flake inputs) will
   # be accessible through 'pkgs.unstable'
-  unstable-packages = final: _prev: {
-    unstable = import inputs.nixpkgs-unstable {
+  stable-packages = final: _prev: {
+    stable = import inputs.nixpkgs-stable {
       system = final.system;
       config.allowUnfree = true;
     };


### PR DESCRIPTION
Use proper name to access stable packages, now instead of using "unstable.package" to access a stable package, you can use "stable.package". Which makes way more sense than the previous